### PR TITLE
command: remove default config and log path

### DIFF
--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -20,6 +20,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
 	"github.com/fatih/color"
 	"github.com/loopholelabs/cmdutils"
 	"github.com/loopholelabs/cmdutils/pkg/config"
@@ -28,10 +34,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-	"log"
-	"os"
-	"path/filepath"
-	"strings"
 )
 
 type SetupCommand[T config.Config] func(cmd *cobra.Command, ch *cmdutils.Helper[T])
@@ -110,15 +112,13 @@ func (c *Command[T]) Execute(ctx context.Context) int {
 func (c *Command[T]) runCmd(ctx context.Context, format *printer.Format, debug *bool) error {
 	c.config = c.newConfig()
 
-	configPath, err := c.config.DefaultConfigPath()
+	configDir, err := c.config.DefaultConfigDir()
 	if err != nil {
 		return err
 	}
 
-	logPath, err := c.config.DefaultLogPath()
-	if err != nil {
-		return err
-	}
+	configPath := path.Join(configDir, c.config.DefaultConfigFile())
+	logPath := path.Join(configDir, c.config.DefaultLogFile())
 
 	c.command.PersistentFlags().StringVar(&cfgFile, "config", "", fmt.Sprintf("Config file (default is %s)", configPath))
 	c.command.PersistentFlags().StringVar(&logFile, "log", logPath, "Log File")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,9 +29,7 @@ type Config interface {
 	Validate() error
 	DefaultConfigDir() (string, error)
 	DefaultConfigFile() string
-	DefaultConfigPath() (string, error)
 	DefaultLogFile() string
-	DefaultLogPath() (string, error)
 	SetConfigFile(configFile string)
 	GetConfigFile() string
 	SetLogFile(logFile string)


### PR DESCRIPTION
Remove the `DefaultConfigPath()` and `DefaultLogPath()` methods from the `config.Config` interface and provide a sensible internal implementation.

Minor quality of life improvement suggestion. As far as I can tell, most implementations follow the pattern implemented internally:

https://github.com/loopholelabs/scale-cli/blob/045a651fab004a153a9bebe19de998970753ab44/internal/config/config.go#L202-L216
https://github.com/loopholelabs/releaser/blob/46ce6869dc5a0f09d23eaa623dc8e4ec32c311b0/internal/config/config.go#L149-L163
https://github.com/loopholelabs/endkey/blob/de22fdef4d05d4e9a7f2ed9e856290497317ec58/internal/config/config.go#L100-L114

The only exception was an internal repo, but I'm not sure if that was intentional.