### PR TITLE
Allow configuring log directory separately from config directory

### DIFF
--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -118,8 +118,13 @@ func (c *Command[T]) runCmd(ctx context.Context, format *printer.Format, debug *
 		return err
 	}
 
+	logDir, err := c.config.DefaultLogDir()
+	if err != nil {
+		return err
+	}
+
 	configPath := path.Join(configDir, c.config.DefaultConfigFile())
-	logPath := path.Join(configDir, c.config.DefaultLogFile())
+	logPath := path.Join(logDir, c.config.DefaultLogFile())
 
 	c.command.PersistentFlags().StringVar(&cfgFile, "config", "", fmt.Sprintf("Config file (default is %s)", configPath))
 	c.command.PersistentFlags().StringVar(&logFile, "log", logPath, "Log File")

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -126,8 +126,8 @@ func (c *Command[T]) runCmd(ctx context.Context, format *printer.Format, debug *
 	configPath := path.Join(configDir, c.config.DefaultConfigFile())
 	logPath := path.Join(logDir, c.config.DefaultLogFile())
 
-	c.command.PersistentFlags().StringVar(&cfgFile, "config", "", fmt.Sprintf("Config file (default is %s)", configPath))
-	c.command.PersistentFlags().StringVar(&logFile, "log", logPath, "Log File")
+	c.command.PersistentFlags().StringVar(&cfgFile, "config", "", fmt.Sprintf(`Config file (default "%s")`, configPath))
+	c.command.PersistentFlags().StringVar(&logFile, "log", logPath, "Log file")
 
 	cobra.OnInitialize(func() {
 		err := c.initConfig()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,6 +29,7 @@ type Config interface {
 	Validate() error
 	DefaultConfigDir() (string, error)
 	DefaultConfigFile() string
+	DefaultLogDir() (string, error)
 	DefaultLogFile() string
 	SetConfigFile(configFile string)
 	GetConfigFile() string


### PR DESCRIPTION
This introduces `config.DefaultLogDir` instead of re-using `config.DefaultConfigDir`. As per the XDG specification, logs don't belong in the _config_ directory, but rather the _state_ directory: https://specifications.freedesktop.org/basedir-spec/0.8/ar01s02.html

The relevant passage from the spec:

```plaintext
    $XDG_STATE_HOME defines the base directory relative to which user-specific state files should be stored. If $XDG_STATE_HOME is either not set or empty, a default equal to $HOME/.local/state should be used.

    The $XDG_STATE_HOME contains state data that should persist between (application) restarts, but that is not important or portable enough to the user that it should be stored in $XDG_DATA_HOME. It may contain:

        actions history (logs, history, recently used files, …)

        current state of the application that can be reused on a restart (view, layout, open files, undo history, …)
```

This important for compatibility with many immutable operating systems where the config directory may be read-only.