### PR TITLE
cmd: fix --log-level help message and viper bind

### DIFF
--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -239,8 +239,8 @@ func (c *Command[T]) runCmd(ctx context.Context, commandType Type) error {
 	}
 
 	c.logLevel = types.InfoLevel
-	c.command.PersistentFlags().VarP(&c.logLevel, "log-level", "", "")
-	if err = viper.BindPFlag("log-level", c.command.PersistentFlags().Lookup("debug")); err != nil {
+	c.command.PersistentFlags().VarP(&c.logLevel, "log-level", "", "Specifies the level of log verbosity. Possible values: [fatal, error, warn, info, debug, trace]")
+	if err = viper.BindPFlag("log-level", c.command.PersistentFlags().Lookup("log-level")); err != nil {
 		return err
 	}
 	_ = c.command.RegisterFlagCompletionFunc("log-level", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {


### PR DESCRIPTION
Add the missing descriptive help message to the `--log-level` flag and fix the Viper config bind.